### PR TITLE
Align charCI with together chatReplyRequest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# fount-charCI
+
+CI harness for fount chars. Local run: `fount-charCI <charDir|user/char> [CI-file]`.
+
+## Together / chatReplyRequest
+
+`src/fount.mjs` builds a minimal `chatReplyRequest` for `CI.runInput` / `CI.runOutput`. Keep it aligned with `src/decl/chatLog.ts` (`UserUid` / `CharUid`, `timelines`, `chat_summary`, extra `supported_functions`, chat_log `uid`). Disable `P2P` in server `starts` — CI does not need the node stack.
+
+`runInput` / `runOutput` only need `interfaces.chat` (not `interfaces.config`). Chars without config (e.g. rule-based bots) must still get these helpers.

--- a/default_data/config.json
+++ b/default_data/config.json
@@ -11,7 +11,8 @@
 					"lockedUntil": null,
 					"refreshTokens": [],
 					"apiKeys": [],
-					"apiRefreshTokens": []
+					"apiRefreshTokens": [],
+					"webauthnCredentials": []
 				},
 				"jobs": {},
 				"locales": [],
@@ -24,5 +25,8 @@
 	},
 	"privateKey": "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgBiR+4xFJsgG5AkxG\njhHn9/u7h9fUpgF0sIyP8q32kV2hRANCAARnSzgUtiNMHemHManmTG/5sDN5vEeJ\nZM7l2MZN/iV1UMLOEwe4daiB1hVZimX89sv9Cq+lIlqMLZI8VxUqXFQl\n-----END PRIVATE KEY-----\n",
 	"publicKey": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZ0s4FLYjTB3phzGp5kxv+bAzebxH\niWTO5djGTf4ldVDCzhMHuHWogdYVWYpl/PbL/QqvpSJajC2SPFcVKlxUJQ==\n-----END PUBLIC KEY-----\n",
-	"uuid": "d3ecb7b6-2a58-45e1-bbe2-ede9fa846e51"
+	"uuid": "d3ecb7b6-2a58-45e1-bbe2-ede9fa846e51",
+	"prelaunch": {
+		"jobparts": []
+	}
 }

--- a/src/fount.mjs
+++ b/src/fount.mjs
@@ -95,8 +95,6 @@ function get_req(diff) {
 		CharUid,
 		locales: ['en-UK'],
 		time: new Date(),
-		chat_log,
-		timelines: [chat_log],
 		chat_summary: '',
 		Update: async () => result,
 		AddChatLogEntry: async (entry) => {

--- a/src/fount.mjs
+++ b/src/fount.mjs
@@ -16,6 +16,7 @@ export async function initFount() {
 				IPC: false,
 				Tray: false,
 				DiscordRPC: false,
+				P2P: false,
 				Base: {
 					AutoUpdate: false
 				}
@@ -61,30 +62,64 @@ export async function unloadChar() {
 function get_req(diff) {
 	let result
 	const { char } = CI
+	const UserUid = 'ci-user'
+	const CharUid = 'ci-char'
+	const normalizeEntry = (entry) => ({
+		name: entry.name ?? entry.role ?? 'user',
+		uid: entry.uid ?? (entry.role === 'char' ? CharUid : UserUid),
+		content: '',
+		files: [],
+		extension: {},
+		time_stamp: new Date(),
+		...entry,
+	})
+	const chat_log = (diff?.chat_log || []).map(normalizeEntry)
 	return result = {
 		supported_functions: {
-			markdown: true, mathjax: true, html: true, unsafe_html: true, files: true, add_message: true,
+			markdown: true,
+			mathjax: true,
+			html: true,
+			unsafe_html: true,
+			files: true,
+			add_message: true,
+			fount_i18nkeys: true,
+			fount_assets: true,
+			fount_themes: true,
 		},
 		chat_name: 'CI',
-		chat_id: 0,
 		char_id: charname,
 		username,
 		UserCharname: username,
+		UserUid,
 		Charname: Object.values(char.info || {})[0]?.name || charname,
+		CharUid,
 		locales: ['en-UK'],
-		chat_log: [],
+		time: new Date(),
+		chat_log,
+		timelines: [chat_log],
+		chat_summary: '',
 		Update: async () => result,
 		AddChatLogEntry: async (entry) => {
-			result.chat_log.push({ name: entry.role, content: '', files: [], ...entry })
+			const written = normalizeEntry({ name: entry.role, content: '', files: [], ...entry })
+			result.chat_log.push(written)
+			return written
 		},
-		world: null, char, user: null, other_chars: {}, chat_scoped_char_memory: {}, plugins: {}, extension: {},
-		...diff
+		world: null,
+		char,
+		user: null,
+		other_chars: {},
+		chat_scoped_char_memory: {},
+		plugins: {},
+		extension: {},
+		...diff,
+		chat_log,
+		timelines: diff?.timelines ?? [chat_log],
 	}
 }
 
 export function setupCharFunctions() {
 	const { char } = CI
-	if (char?.interfaces.config && char?.interfaces.chat) {
+	if (char?.interfaces.chat) {
 		CI.runOutput = async (output, request) => {
 			if (Object(context.output) instanceof Array && context.output.length) {
 				context.isFailed = true


### PR DESCRIPTION
## Summary
- Update CI `chatReplyRequest` for together (`UserUid`/`CharUid`, `timelines`, `chat_summary`, extra supported_functions; drop `chat_id`)
- Disable P2P in CI server starts; allow `runInput`/`runOutput` when only `interfaces.chat` is present (no config required)
- Sync default CI user config fields and document the together request contract in AGENTS.md

## Test plan
- [x] `fount-charCI` against ELIZA (rule-based, no config) — all tests passed
- [ ] Spot-check an AI-source char CI (e.g. Gentian) still loads `runInput`/`runOutput`