### PR TITLE
Align CI mock AI and get_req with together buildPromptStruct

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@ CI harness for fount chars. Local run: `fount-charCI <charDir|user/char> [CI-fil
 
 ## Together / chatReplyRequest
 
-`src/fount.mjs` builds a minimal `chatReplyRequest` for `CI.runInput` / `CI.runOutput`. Keep it aligned with `src/decl/chatLog.ts` (`UserUid` / `CharUid`, `timelines`, `chat_summary`, extra `supported_functions`, chat_log `uid`). Disable `P2P` in server `starts` — CI does not need the node stack.
+`src/fount.mjs` builds a minimal `chatReplyRequest` for `CI.runInput` / `CI.runOutput`. Keep it aligned with `src/decl/chatLog.ts` (`UserUid` / `CharUid`, `timelines`, `chat_summary`, extra `supported_functions`, chat_log `uid`). Use chat shell `BUILTIN_WORLD` / `BUILTIN_PERSONA` — never `world: null` / `user: null` (`buildPromptStruct` reads `*.interfaces`). Disable `P2P` in server `starts` — CI does not need the node stack.
 
 `runInput` / `runOutput` only need `interfaces.chat` (not `interfaces.config`). Chars without config (e.g. rule-based bots) must still get these helpers.
+
+## CI mock AI source
+
+`default_data/.../serviceGenerators/AI/CI/main.mjs` `StructCall` must `Object.assign(base_result, …)` and honour `replyPreviewUpdater` (same contract as real generators). Import `prompt_struct/index.mjs` (directory module, not `prompt_struct.mjs`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ CI harness for fount chars. Local run: `fount-charCI <charDir|user/char> [CI-fil
 
 ## Together / chatReplyRequest
 
-`src/fount.mjs` builds a minimal `chatReplyRequest` for `CI.runInput` / `CI.runOutput`. Keep it aligned with `src/decl/chatLog.ts` (`UserUid` / `CharUid`, `timelines`, `chat_summary`, extra `supported_functions`, chat_log `uid`). Use chat shell `BUILTIN_WORLD` / `BUILTIN_PERSONA` — never `world: null` / `user: null` (`buildPromptStruct` reads `*.interfaces`). Disable `P2P` in server `starts` — CI does not need the node stack.
+`src/fount.mjs` builds a minimal `chatReplyRequest` for `CI.runInput` / `CI.runOutput`. Keep it aligned with `src/decl/chatLog.ts` (`UserUid` / `CharUid`, `timelines`, `chat_summary`, extra `supported_functions`, chat_log `uid`). Leave `world` / `user` as `null` — chars and `buildPromptStruct` must tolerate missing world/persona; do not inject chat shell builtins. Disable `P2P` in server `starts` — CI does not need the node stack.
 
 `runInput` / `runOutput` only need `interfaces.chat` (not `interfaces.config`). Chars without config (e.g. rule-based bots) must still get these helpers.
 

--- a/default_data/users/CI-user/serviceGenerators/AI/CI/main.mjs
+++ b/default_data/users/CI-user/serviceGenerators/AI/CI/main.mjs
@@ -12,7 +12,7 @@ const configTemplate = {}
 import path from 'node:path'
 import url from 'node:url'
 
-import { structPromptToSingle } from '../../../../../../src/public/parts/shells/chat/src/prompt_struct.mjs'
+import { structPromptToSingle } from '../../../../../../src/public/parts/shells/chat/src/prompt_struct/index.mjs'
 const { context } = await import(url.pathToFileURL(path.resolve(process.env.GITHUB_ACTION_PATH + '/index.mjs')))
 
 function getOutput(output, result) {
@@ -62,15 +62,18 @@ async function GetSource(config) {
 				throw e
 			}
 		},
-		StructCall: async (/** @type {prompt_struct_t} */ prompt_struct) => {
+		StructCall: async (/** @type {prompt_struct_t} */ prompt_struct, options = {}) => {
 			const CI = context
+			const { base_result = {}, replyPreviewUpdater } = options
 			CI.result ??= {}
 			CI.result.prompt_struct = prompt_struct
 			CI.result.prompt_single = structPromptToSingle(prompt_struct)
 			try {
-				return {
+				const result = {
 					content: await getOutput(CI.output, CI.result)
 				}
+				replyPreviewUpdater?.(result)
+				return Object.assign(base_result, result)
 			}
 			catch(e) {
 				CI.isFailed = true

--- a/src/fount.mjs
+++ b/src/fount.mjs
@@ -59,11 +59,15 @@ export async function unloadChar() {
 	})
 }
 
-function get_req(diff) {
+async function get_req(diff) {
 	let result
 	const { char } = CI
 	const UserUid = 'ci-user'
 	const CharUid = 'ci-char'
+	const { BUILTIN_WORLD, BUILTIN_PERSONA } = await loadmjs(path.join(
+		import.meta.dirname,
+		'../fount/src/public/parts/shells/chat/src/chat/session/builtinParts.mjs',
+	))
 	const normalizeEntry = (entry) => ({
 		name: entry.name ?? entry.role ?? 'user',
 		uid: entry.uid ?? (entry.role === 'char' ? CharUid : UserUid),
@@ -102,9 +106,9 @@ function get_req(diff) {
 			result.chat_log.push(written)
 			return written
 		},
-		world: null,
+		world: BUILTIN_WORLD,
 		char,
-		user: null,
+		user: BUILTIN_PERSONA,
 		other_chars: {},
 		chat_scoped_char_memory: {},
 		plugins: {},
@@ -124,7 +128,7 @@ export function setupCharFunctions() {
 				throw new Error('CI.output is not an empty array after the reqly, check your CI code.')
 			}
 			context.output = output
-			const req = get_req(request)
+			const req = await get_req(request)
 			const result = await char.interfaces.chat.GetReply(req)
 			return result
 		}
@@ -133,7 +137,7 @@ export function setupCharFunctions() {
 			if (!Array.isArray(input)) input = [input]
 
 			context.result = {}
-			const req = get_req({ chat_log: input, ...request })
+			const req = await get_req({ chat_log: input, ...request })
 			const reply = await char.interfaces.chat.GetReply(req)
 			return {
 				reply,

--- a/src/fount.mjs
+++ b/src/fount.mjs
@@ -59,15 +59,11 @@ export async function unloadChar() {
 	})
 }
 
-async function get_req(diff) {
+function get_req(diff) {
 	let result
 	const { char } = CI
 	const UserUid = 'ci-user'
 	const CharUid = 'ci-char'
-	const { BUILTIN_WORLD, BUILTIN_PERSONA } = await loadmjs(path.join(
-		import.meta.dirname,
-		'../fount/src/public/parts/shells/chat/src/chat/session/builtinParts.mjs',
-	))
 	const normalizeEntry = (entry) => ({
 		name: entry.name ?? entry.role ?? 'user',
 		uid: entry.uid ?? (entry.role === 'char' ? CharUid : UserUid),
@@ -106,9 +102,9 @@ async function get_req(diff) {
 			result.chat_log.push(written)
 			return written
 		},
-		world: BUILTIN_WORLD,
+		world: null,
 		char,
-		user: BUILTIN_PERSONA,
+		user: null,
 		other_chars: {},
 		chat_scoped_char_memory: {},
 		plugins: {},
@@ -128,7 +124,7 @@ export function setupCharFunctions() {
 				throw new Error('CI.output is not an empty array after the reqly, check your CI code.')
 			}
 			context.output = output
-			const req = await get_req(request)
+			const req = get_req(request)
 			const result = await char.interfaces.chat.GetReply(req)
 			return result
 		}
@@ -137,7 +133,7 @@ export function setupCharFunctions() {
 			if (!Array.isArray(input)) input = [input]
 
 			context.result = {}
-			const req = await get_req({ chat_log: input, ...request })
+			const req = get_req({ chat_log: input, ...request })
 			const reply = await char.interfaces.chat.GetReply(req)
 			return {
 				reply,


### PR DESCRIPTION
## Summary
- CI AI `StructCall` assigns into `base_result` and calls `replyPreviewUpdater`
- Import `prompt_struct/index.mjs` (was stale `prompt_struct.mjs`)
- `get_req` uses `BUILTIN_WORLD` / `BUILTIN_PERSONA` so `buildPromptStruct` works
- Document the contract in AGENTS.md

Fixes #3

## Test plan
- [x] Local `fount-charCI` against daisyUI_helper — 9/9 passed
- [x] Local `fount-charCI` against Saira — 10/10 passed
- [x] Local `fount-charCI` against ELIZA — still green